### PR TITLE
feat: 게시판 글 생성 구현

### DIFF
--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -1,3 +1,4 @@
+import { TQuestionField } from '../types/questionBoard'
 import api from './index'
 
 export const init = async () => {
@@ -9,6 +10,7 @@ export const init = async () => {
   }
 }
 
+// READ
 export const getAllBoard = async () => {
   try {
     const res = await api.get('/board/all')
@@ -25,3 +27,17 @@ export const getBoardDetail = async (id: string) => {
     return console.error(err)
   }
 }
+
+// CREATE
+export const createBoard = async (formData: TQuestionField) => {
+  try {
+    const res = await api.post('/board/create-board', formData)
+    return res.data
+  } catch (err) {
+    return console.error(err)
+  }
+}
+
+// UPDATE
+
+// DELETE

--- a/src/constants/questionBoard.ts
+++ b/src/constants/questionBoard.ts
@@ -14,6 +14,12 @@ export const questionPoints = [
   { id: 3, type: '많이', point: 500 },
 ]
 
+export const questionAccessList = [
+  { id: 1, access: 'public', option: '공개' },
+  { id: 2, access: 'partner', option: '파트너 공개' },
+  { id: 3, access: 'private', option: '비공개' },
+]
+
 export const questionList = [
   {
     id: 1,

--- a/src/pages/createQuestion.tsx
+++ b/src/pages/createQuestion.tsx
@@ -36,7 +36,7 @@ function CreateQuestion() {
         board_category: values.board_category,
         board_access: values.board_access,
         board_point: values.board_point,
-        writer_user_info: { user_type: 'questioner' },
+        writer_user_info: { user_type: 'questioner', writer_id: '기믄정' },
         board_img: [],
         // board_create_time: Date.now(),
       }

--- a/src/pages/createQuestion.tsx
+++ b/src/pages/createQuestion.tsx
@@ -2,7 +2,11 @@ import { PlusOutlined } from '@ant-design/icons'
 import { Button, ConfigProvider, Form, Input, Select, Upload } from 'antd'
 import { useNavigate } from 'react-router-dom'
 import Title from '../components_ques/Title'
-import { questionPoints, questionTypes } from '../constants/questionBoard'
+import {
+  questionAccessList,
+  questionPoints,
+  questionTypes,
+} from '../constants/questionBoard'
 import { TQuestionField } from '../types/questionBoard'
 import { createBoard } from '../apis/board'
 
@@ -34,6 +38,7 @@ function CreateQuestion() {
         board_point: values.board_point,
         writer_user_info: { user_type: 'questioner' },
         board_img: [],
+        // board_create_time: Date.now(),
       }
       await createBoard(boardData)
     } catch (err) {
@@ -116,6 +121,23 @@ function CreateQuestion() {
               </div>
             </div>
             <Form.Item<TQuestionField>
+              label="공개 범위를 설정해주세요"
+              name="board_access"
+              className="form_label"
+              rules={[{ required: true, message: '공개 범위를 설정해주세요!' }]}
+            >
+              <Select
+                placeholder="누구에게 공개하실 건가요?"
+                className="form_selectBox"
+              >
+                {questionAccessList.map((ques) => (
+                  <Select.Option key={ques.id} value={ques.access}>
+                    {ques.option}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item<TQuestionField>
               label="유형을 설정해주세요"
               name="board_category"
               className="form_label"
@@ -156,7 +178,6 @@ function CreateQuestion() {
                 신속히 받을 수 있습니다.
               </p>
             </div>
-
             <Form.Item>
               <div className="button_section">
                 <div className="form_button">

--- a/src/pages/createQuestion.tsx
+++ b/src/pages/createQuestion.tsx
@@ -34,7 +34,7 @@ function CreateQuestion() {
         board_title: values.board_title,
         board_contents: values.board_contents,
         board_category: values.board_category,
-        board_access: 'public',
+        board_access: values.board_access,
         board_point: values.board_point,
         writer_user_info: { user_type: 'questioner' },
         board_img: [],

--- a/src/pages/createQuestion.tsx
+++ b/src/pages/createQuestion.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import Title from '../components_ques/Title'
 import { questionPoints, questionTypes } from '../constants/questionBoard'
 import { TQuestionField } from '../types/questionBoard'
+import { createBoard } from '../apis/board'
 
 const { TextArea } = Input
 
@@ -23,8 +24,26 @@ function CreateQuestion() {
 
   const navigate = useNavigate()
 
-  const onFinish = (values: unknown) => {
+  const submitForm = async (values: TQuestionField) => {
+    try {
+      const boardData = {
+        board_title: values.board_title,
+        board_contents: values.board_contents,
+        board_category: values.board_category,
+        board_access: 'public',
+        board_point: values.board_point,
+        writer_user_info: { user_type: 'questioner' },
+        board_img: [],
+      }
+      await createBoard(boardData)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const onFinish = (values: TQuestionField) => {
     console.log('Success:', values)
+    submitForm(values)
 
     // redirect
     navigate('/questionBoard')
@@ -54,7 +73,7 @@ function CreateQuestion() {
           >
             <Form.Item<TQuestionField>
               label="제목을 입력해주세요"
-              name="title"
+              name="board_title"
               className="form_label"
               rules={[{ required: true, message: '제목을 입력해주세요!' }]}
             >
@@ -62,7 +81,7 @@ function CreateQuestion() {
             </Form.Item>
             <Form.Item<TQuestionField>
               label="내용을 작성해주세요"
-              name="content"
+              name="board_contents"
               className="form_label"
               rules={[{ required: true, message: '내용을 작성해주세요!' }]}
             >
@@ -75,7 +94,7 @@ function CreateQuestion() {
             <div className="form_image">
               <Form.Item<TQuestionField>
                 label="이미지를 첨부해주세요"
-                name="photo"
+                name="board_img"
                 className="form_label"
                 valuePropName="fileList"
                 getValueFromEvent={normFile}
@@ -98,7 +117,7 @@ function CreateQuestion() {
             </div>
             <Form.Item<TQuestionField>
               label="유형을 설정해주세요"
-              name="type"
+              name="board_category"
               className="form_label"
               rules={[{ required: true, message: '유형을 설정해주세요!' }]}
             >
@@ -115,12 +134,12 @@ function CreateQuestion() {
             </Form.Item>
             <Form.Item<TQuestionField>
               label="용돈을 설정해주세요"
-              name="point"
+              name="board_point"
               rules={[{ required: true, message: '용돈을 설정해주세요!' }]}
             >
               <Select placeholder="기본" className="form_selectBox">
                 {questionPoints.map((ques) => (
-                  <Select.Option key={ques.type} value={ques.type}>
+                  <Select.Option key={ques.type} value={ques.point}>
                     {ques.type}
                   </Select.Option>
                 ))}

--- a/src/pages/questionDetail.tsx
+++ b/src/pages/questionDetail.tsx
@@ -24,6 +24,11 @@ type AnswersType = {
   comments: Array<CommentsType>
 }
 
+interface IWriterInfo {
+  user_type: string
+  writer_id: string
+}
+
 interface IPostDataType {
   answers: Array<AnswersType>
   board_access: string
@@ -36,8 +41,9 @@ interface IPostDataType {
   selected_answer: Array<AnswersType>
   status: string
   views: number
-  writer_id: string
+  // writer_id: string
   _id: string
+  writer_user_info: IWriterInfo
 }
 
 export default function DetailPageAnswerer(props: QuestionDetailProps) {
@@ -86,7 +92,8 @@ export default function DetailPageAnswerer(props: QuestionDetailProps) {
                 {postData?.board_point}
               </p>
               <p className="questionDetail_header_property_category">
-                {postData?.writer_id} · {postData?.board_category[0]}
+                {postData?.writer_user_info.writer_id} ·{' '}
+                {postData?.board_category}
               </p>
               <p className="questionDetail_header_property_time">
                 {timeDifference(postData?.create_time as unknown as string)}
@@ -275,7 +282,8 @@ export default function DetailPageAnswerer(props: QuestionDetailProps) {
             <div className="questionDetail_header_sub">
               <p className="questionDetail_header_sub_property">
                 {/* 카테고리 string으로 변경되면 수정할 것 */}
-                {postData?.writer_id} · {postData?.board_category[0]} ·{' '}
+                {postData?.writer_user_info.writer_id} ·{' '}
+                {postData?.board_category} ·{' '}
                 {timeDifference(postData?.create_time as unknown as string)}
               </p>
               <p className="questionDetail_header_sub_modify">

--- a/src/types/questionBoard.ts
+++ b/src/types/questionBoard.ts
@@ -12,9 +12,11 @@ export interface IQuestion {
 }
 
 export type TQuestionField = {
-  point?: number
-  type?: string
-  title?: string
-  photo?: string
-  content?: string
+  board_title: string
+  board_contents: string
+  board_category: string
+  board_access: string
+  board_point: number
+  writer_user_info: object
+  board_img?: Array<string>
 }


### PR DESCRIPTION


---

## 이야기해 볼 것

### 1. 게시판 글 생성시, 결과

create_time도 같이 넘어와야 하지 않을까요? 
(첫 번째, 두 번째 board 데이터가 기존 로직의 결과)
(세 번째 board 데이터가 create_time을 프론트에서 보내서 테스트 한 값)

<img width="796" alt="스크린샷 2023-12-13 오후 2 37 34" src="https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/2695629e-37c4-48de-b785-94addacca040">

수정해 본 백엔드 코드. ( 아직 깃허브 파일에는 반영 X )
<img width="644" alt="스크린샷 2023-12-13 오후 2 39 04" src="https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/3306c0d3-d1bd-4252-b812-c7ed677d6063">

### 2. board_img는 백에서 어떻게 할 지 고민 중인 것 같아 테스트 안 했습니다.

### 3. `TQuestionField`를 사용 중인 사람이 있다면,, 살짝 수정되었으니 참고하세요