### PR TITLE
feat: 게시판 글 수정 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import Subway18 from './pages/SimulationSubWay/Subway18'
 import Subway19 from './pages/SimulationSubWay/Subway19'
 import SearchPartner from './pages/searchPartner'
 import SubWay9 from './pages/SimulationSubWay/Subway9'
+import UpdateQuestion from './pages/modifyQuestion'
 
 function App() {
   const [user, setUser] = useState<boolean>(false)
@@ -81,6 +82,7 @@ function App() {
           <Route path="/questionBoard" element={<QuestionBoard />} />
           <Route path="/createQuestion" element={<CreateQuestion />} />
           <Route path="/searchPartner" element={<SearchPartner />} />
+          <Route path="/modify/:id" element={<UpdateQuestion />} />
         </Route>
       </Routes>
     </div>

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -39,5 +39,13 @@ export const createBoard = async (formData: TQuestionField) => {
 }
 
 // UPDATE
+export const modifyBoard = async (id: string, formData: TQuestionField) => {
+  try {
+    const res = await api.put(`/board//modify-board/${id}`, formData)
+    return res.data
+  } catch (err) {
+    return console.error(err)
+  }
+}
 
 // DELETE

--- a/src/pages/modifyQuestion.tsx
+++ b/src/pages/modifyQuestion.tsx
@@ -10,7 +10,7 @@ import {
   questionPoints,
   questionTypes,
 } from '../constants/questionBoard'
-import { getBoardDetail } from '../apis/board'
+import { getBoardDetail, modifyBoard } from '../apis/board'
 
 const { TextArea } = Input
 
@@ -47,12 +47,28 @@ function UpdateQuestion() {
     }
   }
 
-  useEffect(() => {
-    getBoard()
-  }, [])
+  const modifyForm = async (values: TQuestionField) => {
+    try {
+      const boardId = params.id as unknown as string
+      const boardData = {
+        board_title: values.board_title,
+        board_contents: values.board_contents,
+        board_category: values.board_category,
+        board_access: values.board_access,
+        board_point: values.board_point,
+        writer_user_info: { writer_id: '기믄정' },
+        board_img: [],
+        // board_create_time: Date.now(),
+      }
+      await modifyBoard(boardId, boardData)
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   const onFinish = (values: TQuestionField) => {
     console.log('Success:', values)
+    modifyForm(values)
 
     // redirect
     navigate('/questionBoard')
@@ -61,6 +77,11 @@ function UpdateQuestion() {
   const onFinishFailed = (errorInfo: unknown) => {
     console.log('Failed:', errorInfo)
   }
+
+  useEffect(() => {
+    getBoard()
+  }, [])
+
   return (
     <ConfigProvider
       theme={{

--- a/src/pages/modifyQuestion.tsx
+++ b/src/pages/modifyQuestion.tsx
@@ -1,0 +1,206 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { PlusOutlined } from '@ant-design/icons'
+import { Button, ConfigProvider, Form, Input, Select, Upload } from 'antd'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import { TQuestionField } from '../types/questionBoard'
+import Title from '../components_ques/Title'
+import {
+  questionAccessList,
+  questionPoints,
+  questionTypes,
+} from '../constants/questionBoard'
+import { getBoardDetail } from '../apis/board'
+
+const { TextArea } = Input
+
+const normFile = (e: { fileList: unknown }) => {
+  if (Array.isArray(e)) {
+    return e
+  }
+  return e?.fileList
+}
+
+type TitleType = {
+  data: [string, string, string, string]
+}
+
+const currentUrl: TitleType['data'] = ['질문하기', '/createQuestion', '', '']
+
+function UpdateQuestion() {
+  const params = useParams()
+  const navigate = useNavigate()
+  const [form] = Form.useForm()
+
+  const getBoard = async () => {
+    try {
+      const prevData = await getBoardDetail(params.id as unknown as string)
+      form.setFieldsValue({
+        board_title: prevData.board_title,
+        board_contents: prevData.board_contents,
+        board_access: prevData.board_access,
+        board_category: prevData.board_category,
+        board_point: prevData.board_point,
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    getBoard()
+  }, [])
+
+  const onFinish = (values: TQuestionField) => {
+    console.log('Success:', values)
+
+    // redirect
+    navigate('/questionBoard')
+  }
+
+  const onFinishFailed = (errorInfo: unknown) => {
+    console.log('Failed:', errorInfo)
+  }
+  return (
+    <ConfigProvider
+      theme={{
+        token: {
+          fontFamily: 'KoPubWorld-Batang-Medium',
+        },
+      }}
+    >
+      <div className="innerBox ques">
+        <Title data={currentUrl} />
+        <div className="submit_question">
+          <Form
+            initialValues={{ remember: true }}
+            onFinish={onFinish}
+            onFinishFailed={onFinishFailed}
+            autoComplete="off"
+            layout="vertical"
+            form={form}
+          >
+            <Form.Item<TQuestionField>
+              label="제목을 입력해주세요"
+              name="board_title"
+              className="form_label"
+              rules={[{ required: true, message: '제목을 입력해주세요!' }]}
+            >
+              <Input placeholder="제목을 입력해주세요" className="form_value" />
+            </Form.Item>
+            <Form.Item<TQuestionField>
+              label="내용을 작성해주세요"
+              name="board_contents"
+              className="form_label"
+              rules={[{ required: true, message: '내용을 작성해주세요!' }]}
+            >
+              <TextArea
+                rows={6}
+                placeholder="궁금한 점을 자세히 적어주세요"
+                className="form_value"
+              />
+            </Form.Item>
+            <div className="form_image">
+              <Form.Item<TQuestionField>
+                label="이미지를 첨부해주세요"
+                name="board_img"
+                className="form_label"
+                valuePropName="fileList"
+                getValueFromEvent={normFile}
+              >
+                <Upload action="/upload.do" listType="picture-card">
+                  <div>
+                    <PlusOutlined />
+                    <div style={{ marginTop: 8 }}>Upload</div>
+                  </div>
+                </Upload>
+              </Form.Item>
+              <div className="form_notice">
+                <img
+                  src="/img/exclamation-circle.svg"
+                  className="exclamation-icon"
+                  alt="exclamation-icon"
+                />
+                <p>필수 사항이 아닙니다</p>
+              </div>
+            </div>
+            <Form.Item<TQuestionField>
+              label="공개 범위를 설정해주세요"
+              name="board_access"
+              className="form_label"
+              rules={[{ required: true, message: '공개 범위를 설정해주세요!' }]}
+            >
+              <Select
+                placeholder="누구에게 공개하실 건가요?"
+                className="form_selectBox"
+              >
+                {questionAccessList.map((ques) => (
+                  <Select.Option key={ques.id} value={ques.access}>
+                    {ques.option}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item<TQuestionField>
+              label="유형을 설정해주세요"
+              name="board_category"
+              className="form_label"
+              rules={[{ required: true, message: '유형을 설정해주세요!' }]}
+            >
+              <Select
+                placeholder="어떤 유형에 해당하는 질문인가요?"
+                className="form_selectBox"
+              >
+                {questionTypes.map((ques) => (
+                  <Select.Option key={ques.type} value={ques.type}>
+                    {ques.type}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item<TQuestionField>
+              label="용돈을 설정해주세요"
+              name="board_point"
+              rules={[{ required: true, message: '용돈을 설정해주세요!' }]}
+            >
+              <Select placeholder="기본" className="form_selectBox">
+                {questionPoints.map((ques) => (
+                  <Select.Option key={ques.type} value={ques.point}>
+                    {ques.type}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <div className="form_notice">
+              <img
+                src="/img/exclamation-circle.svg"
+                className="exclamation-icon"
+                alt="exclamation-icon"
+              />
+              <p>
+                채택한 답변자에게 지급할 용돈을 설정해주세요. 답변을 좀 더
+                신속히 받을 수 있습니다.
+              </p>
+            </div>
+            <Form.Item>
+              <div className="button_section">
+                <div className="form_button">
+                  <Button htmlType="reset">
+                    <p>작성 취소하기</p>
+                  </Button>
+                </div>
+                <div className="form_button submit">
+                  <Button htmlType="submit">
+                    <p>질문 수정하기</p>
+                  </Button>
+                </div>
+              </div>
+            </Form.Item>
+          </Form>
+        </div>
+      </div>
+    </ConfigProvider>
+  )
+}
+
+export default UpdateQuestion

--- a/src/pages/questionDetail.tsx
+++ b/src/pages/questionDetail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { useEffect, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import '../styles/questionDetail.scss'
@@ -286,17 +287,19 @@ export default function DetailPageAnswerer(props: QuestionDetailProps) {
                 {postData?.board_category} ·{' '}
                 {timeDifference(postData?.create_time as unknown as string)}
               </p>
-              <p className="questionDetail_header_sub_modify">
+              <div className="questionDetail_header_sub_modify">
                 {/* 사용자가 게시글의 주인인 경우 조건 추가 해서 렌더링 */}
-                <div className="questionDetail_header_sub_modify_modify">
-                  <img src="/img/detail_pen_icon.svg" alt="수정하기" />
-                  <p>게시물 수정하기</p>
-                </div>
+                <Link to={`/modify/${postData?._id}`}>
+                  <div className="questionDetail_header_sub_modify_modify">
+                    <img src="/img/detail_pen_icon.svg" alt="수정하기" />
+                    <p>게시물 수정하기</p>
+                  </div>
+                </Link>
                 <div className="questionDetail_header_sub_modify_delete">
                   <img src="/img/detail_waste_icon.svg" alt="삭제하기" />
                   <p>게시물 삭제하기</p>
                 </div>
-              </p>
+              </div>
             </div>
           </div>
           <div className="questionDetail_detail">


### PR DESCRIPTION
## 이야기해 볼 것
### 1. 게시판 글 수정 페이지가 없어서 후다닥 퍼블리싱 했습니다.

- 퍼블리싱 디자인 피드백도 환영합니당
- 수정 시 url 접근은 아래 사진에서 보다시피 `/board/modify/:id`입니다.

<img width="1552" alt="스크린샷 2023-12-13 오후 11 05 55" src="https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/07dd9d58-f4ca-499c-934a-06ecb1b6beed">

## 끄적끄적

1. 내 코드.. 이게 최선일까..? 🥺 맘에 들지 않아요. 더러운 코드 개선에 좋은 의견 있으면 야무지게 반영하겠습니다.

2. **PATCH**와 **PUT**의 차이를 알고 있나요? 글 수정의 상황에서는 어떤 방법이 베스트라고 생각하시는지.. 의견 구합니다.
( 백엔드에서는 게시판 하나의 전체 DB를 다 변경해주는 PUT 로직이라 나도 `api.put` 으로 수정하긴 함)