### PR TITLE
feat: 게시글 글 목록 페이지에서 CRUD 구현

### DIFF
--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -88,3 +88,11 @@ export const modifyBoard = async (id: string, formData: TQuestionField) => {
 }
 
 // DELETE
+export const deleteBoard = async (id: string) => {
+  try {
+    return await api.delete(`/board/board/delete/${id}`)
+  } catch (err) {
+    console.error(err)
+    throw err
+  }
+}

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -80,7 +80,7 @@ export const createComment = async (
 // UPDATE
 export const modifyBoard = async (id: string, formData: TQuestionField) => {
   try {
-    const res = await api.put(`/board//modify-board/${id}`, formData)
+    const res = await api.put(`/board/board/modify/${id}`, formData)
     return res.data
   } catch (err) {
     return console.error(err)

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -13,7 +13,7 @@ export const init = async () => {
 // READ
 export const getAllBoard = async () => {
   try {
-    const res = await api.get('/board/all')
+    const res = await api.get('/board/boards')
     return res.data
   } catch (err) {
     return console.error(err)

--- a/src/apis/board.ts
+++ b/src/apis/board.ts
@@ -31,7 +31,7 @@ export const getBoardDetail = async (id: string) => {
 // CREATE
 export const createBoard = async (formData: TQuestionField) => {
   try {
-    const res = await api.post('/board/create-board', formData)
+    const res = await api.post('/board/board/add', formData)
     return res.data
   } catch (err) {
     return console.error(err)

--- a/src/pages/modifyQuestion.tsx
+++ b/src/pages/modifyQuestion.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { PlusOutlined } from '@ant-design/icons'
 import { Button, ConfigProvider, Form, Input, Select, Upload } from 'antd'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useEffect } from 'react'
 import { TQuestionField } from '../types/questionBoard'
 import Title from '../components_ques/Title'
@@ -206,9 +206,11 @@ function UpdateQuestion() {
             <Form.Item>
               <div className="button_section">
                 <div className="form_button">
-                  <Button htmlType="reset">
-                    <p>작성 취소하기</p>
-                  </Button>
+                  <Link to="/questionBoard">
+                    <Button htmlType="button">
+                      <p>작성 취소하기</p>
+                    </Button>
+                  </Link>
                 </div>
                 <div className="form_button submit">
                   <Button htmlType="submit">

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -89,56 +89,60 @@ function QuestionBoard() {
         </div>
         <div className="questionBox">
           {currentItems.map((ques: IQuestion) => (
-            <div key={ques._id} className="question">
-              <div className="question_header">
-                <div className="question_property">
-                  <p className="question_property_point">{ques.board_point}</p>
-                  <p className="question_property_type">
-                    {ques.board_category}
-                  </p>
-                  <div className="divide-circle" />
-                  <p className="question_property_date">
-                    {formatDate(ques.create_time)}
-                  </p>
+            <Link to={`/quest_detail/${ques._id}`}>
+              <div key={ques._id} className="question">
+                <div className="question_header">
+                  <div className="question_property">
+                    <p className="question_property_point">
+                      {ques.board_point}
+                    </p>
+                    <p className="question_property_type">
+                      {ques.board_category}
+                    </p>
+                    <div className="divide-circle" />
+                    <p className="question_property_date">
+                      {formatDate(ques.create_time)}
+                    </p>
+                  </div>
+                  <div className="question_control">
+                    <Link to={`/modify/${ques._id}`}>
+                      <p className="question_control_edit">수정</p>
+                    </Link>
+                    <div
+                      onClick={() => deletePost(ques?._id)}
+                      onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          deletePost(ques?._id)
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <p className="question_control_delete">삭제</p>
+                    </div>
+                  </div>
                 </div>
-                <div className="question_control">
-                  <Link to={`/modify/${ques._id}`}>
-                    <p className="question_control_edit">수정</p>
-                  </Link>
-                  <div
-                    onClick={() => deletePost(ques?._id)}
-                    onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        deletePost(ques?._id)
-                      }
-                    }}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <p className="question_control_delete">삭제</p>
+                <div className="question_title">
+                  <p>{ques.board_title}</p>
+                  {ques.board_img.length !== 0 && (
+                    <img src="/img/photo_icon.svg" alt="photos-icon" />
+                  )}
+                </div>
+                <div className="question_footer">
+                  <p className="question_detail">{ques.board_contents}</p>
+                  <div className="question_counts">
+                    <div className="question_counts_footer_answers">
+                      <img src="/img/chat_icon.svg" alt="chat-icon" />
+                      <p>답변 {ques.answers}</p>
+                    </div>
+                    <div className="question_counts_footer_views">
+                      <img src="/img/eye_icon.svg" alt="eye-icon" />
+                      <p>조회수 {ques.views}</p>
+                    </div>
                   </div>
                 </div>
               </div>
-              <div className="question_title">
-                <p>{ques.board_title}</p>
-                {ques.board_img.length !== 0 && (
-                  <img src="/img/photo_icon.svg" alt="photos-icon" />
-                )}
-              </div>
-              <div className="question_footer">
-                <p className="question_detail">{ques.board_contents}</p>
-                <div className="question_counts">
-                  <div className="question_counts_footer_answers">
-                    <img src="/img/chat_icon.svg" alt="chat-icon" />
-                    <p>답변 {ques.answers}</p>
-                  </div>
-                  <div className="question_counts_footer_views">
-                    <img src="/img/eye_icon.svg" alt="eye-icon" />
-                    <p>조회수 {ques.views}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
+            </Link>
           ))}
         </div>
         <Pagination

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -8,6 +8,7 @@ import setPagination from '../utils/pagination'
 import { IQuestion } from '../types/questionBoard'
 import Title from '../components_ques/Title'
 import { getAllBoard } from '../apis/board'
+import formatDate from '../utils/formateDate'
 
 type TitleType = {
   data: [string, string, string, string]
@@ -80,7 +81,9 @@ function QuestionBoard() {
                     {ques.board_category}
                   </p>
                   <div className="divide-circle" />
-                  <p className="question_property_date">{ques.create_time}</p>
+                  <p className="question_property_date">
+                    {formatDate(ques.create_time)}
+                  </p>
                 </div>
                 <div className="question_control">
                   <p className="question_control_edit">수정</p>

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { questionTypes } from '../constants/questionBoard'
 import RoundBtn from '../composables/Button/RoundBtn'
 import ToggleBtn from '../composables/Button/ToggleBtn'
@@ -86,7 +87,9 @@ function QuestionBoard() {
                   </p>
                 </div>
                 <div className="question_control">
-                  <p className="question_control_edit">수정</p>
+                  <Link to={`/modify/${ques._id}`}>
+                    <p className="question_control_edit">수정</p>
+                  </Link>
                   <p className="question_control_delete">삭제</p>
                 </div>
               </div>

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -14,7 +14,7 @@ type TitleType = {
 function QuestionBoard() {
   const itemsPerPage = 5
   const [currentPage, setCurrentPage] = useState(1)
-  const { sortedList, currentItems } = setPagination(
+  const { currentItems } = setPagination(
     questionList,
     currentPage,
     itemsPerPage,
@@ -93,7 +93,7 @@ function QuestionBoard() {
         </div>
         <Pagination
           itemsPerPage={itemsPerPage}
-          totalItems={sortedList.length}
+          totalItems={currentItems.length}
           currentPage={currentPage}
           onPageChange={handlePageChange}
         />

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { questionTypes } from '../constants/questionBoard'
 import RoundBtn from '../composables/Button/RoundBtn'
 import ToggleBtn from '../composables/Button/ToggleBtn'
@@ -8,7 +8,7 @@ import Pagination from '../composables/Pagination'
 import setPagination from '../utils/pagination'
 import { IQuestion } from '../types/questionBoard'
 import Title from '../components_ques/Title'
-import { getAllBoard } from '../apis/board'
+import { deleteBoard, getAllBoard } from '../apis/board'
 import formatDate from '../utils/formateDate'
 
 type TitleType = {
@@ -16,6 +16,8 @@ type TitleType = {
 }
 
 function QuestionBoard() {
+  const navigate = useNavigate()
+
   const itemsPerPage = 5
   const [currentPage, setCurrentPage] = useState(1)
   const [questionList, setQuestionList] = useState<Array<IQuestion>>([])
@@ -39,9 +41,22 @@ function QuestionBoard() {
     }
   }
 
+  const deletePost = async (boardId: string | undefined) => {
+    try {
+      await deleteBoard(boardId as unknown as string)
+      navigate('/questionBoard')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   useEffect(() => {
     getQuestions()
   }, [])
+
+  useEffect(() => {
+    getQuestions()
+  }, [questionList])
 
   return (
     <div className="innerBox ques">
@@ -90,7 +105,18 @@ function QuestionBoard() {
                   <Link to={`/modify/${ques._id}`}>
                     <p className="question_control_edit">수정</p>
                   </Link>
-                  <p className="question_control_delete">삭제</p>
+                  <div
+                    onClick={() => deletePost(ques?._id)}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        deletePost(ques?._id)
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <p className="question_control_delete">삭제</p>
+                  </div>
                 </div>
               </div>
               <div className="question_title">

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -89,8 +89,8 @@ function QuestionBoard() {
         </div>
         <div className="questionBox">
           {currentItems.map((ques: IQuestion) => (
-            <Link to={`/quest_detail/${ques._id}`}>
-              <div key={ques._id} className="question">
+            <div key={ques._id} className="question">
+              <Link to={`/quest_detail/${ques._id}`}>
                 <div className="question_header">
                   <div className="question_property">
                     <p className="question_property_point">
@@ -141,8 +141,8 @@ function QuestionBoard() {
                     </div>
                   </div>
                 </div>
-              </div>
-            </Link>
+              </Link>
+            </div>
           ))}
         </div>
         <Pagination

--- a/src/pages/questionBoard.tsx
+++ b/src/pages/questionBoard.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react'
-import { questionList, questionTypes } from '../constants/questionBoard'
+/* eslint-disable no-underscore-dangle */
+import { useEffect, useState } from 'react'
+import { questionTypes } from '../constants/questionBoard'
 import RoundBtn from '../composables/Button/RoundBtn'
 import ToggleBtn from '../composables/Button/ToggleBtn'
 import Pagination from '../composables/Pagination'
 import setPagination from '../utils/pagination'
 import { IQuestion } from '../types/questionBoard'
 import Title from '../components_ques/Title'
+import { getAllBoard } from '../apis/board'
 
 type TitleType = {
   data: [string, string, string, string]
@@ -14,6 +16,7 @@ type TitleType = {
 function QuestionBoard() {
   const itemsPerPage = 5
   const [currentPage, setCurrentPage] = useState(1)
+  const [questionList, setQuestionList] = useState<Array<IQuestion>>([])
   const { currentItems } = setPagination(
     questionList,
     currentPage,
@@ -24,6 +27,19 @@ function QuestionBoard() {
   }
 
   const currentUrl: TitleType['data'] = ['질문하기', '/questionBoard', '', '']
+
+  const getQuestions = async () => {
+    try {
+      const res = await getAllBoard()
+      setQuestionList(() => res)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    getQuestions()
+  }, [])
 
   return (
     <div className="innerBox ques">
@@ -56,13 +72,15 @@ function QuestionBoard() {
         </div>
         <div className="questionBox">
           {currentItems.map((ques: IQuestion) => (
-            <div key={ques.id} className="question">
+            <div key={ques._id} className="question">
               <div className="question_header">
                 <div className="question_property">
-                  <p className="question_property_point">{ques.point}</p>
-                  <p className="question_property_type">{ques.type}</p>
+                  <p className="question_property_point">{ques.board_point}</p>
+                  <p className="question_property_type">
+                    {ques.board_category}
+                  </p>
                   <div className="divide-circle" />
-                  <p className="question_property_date">{ques.date}</p>
+                  <p className="question_property_date">{ques.create_time}</p>
                 </div>
                 <div className="question_control">
                   <p className="question_control_edit">수정</p>
@@ -70,13 +88,13 @@ function QuestionBoard() {
                 </div>
               </div>
               <div className="question_title">
-                <p>{ques.title}</p>
-                {ques.photo !== '' && (
+                <p>{ques.board_title}</p>
+                {ques.board_img.length !== 0 && (
                   <img src="/img/photo_icon.svg" alt="photos-icon" />
                 )}
               </div>
               <div className="question_footer">
-                <p className="question_detail">{ques.content}</p>
+                <p className="question_detail">{ques.board_contents}</p>
                 <div className="question_counts">
                   <div className="question_counts_footer_answers">
                     <img src="/img/chat_icon.svg" alt="chat-icon" />

--- a/src/pages/questionDetail.tsx
+++ b/src/pages/questionDetail.tsx
@@ -1,9 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 import { useEffect, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useNavigate } from 'react-router-dom'
 import '../styles/questionDetail.scss'
 import PartnerRequest from '../components_ques/PartnerRequest'
-import { createAnswer, createComment, getBoardDetail } from '../apis/board'
+import {
+  createAnswer,
+  createComment,
+  deleteBoard,
+  getBoardDetail,
+} from '../apis/board'
 import timeDifference from '../utils/timeDifference'
 // props 타입 설정(유저)
 interface QuestionDetailProps {
@@ -61,6 +66,7 @@ type CommentInputRefType = { id: string; ref: HTMLTextAreaElement | null }
 
 export default function DetailPageAnswerer(props: QuestionDetailProps) {
   const params = useParams()
+  const navigate = useNavigate()
   const [postData, setPostData] = useState<IPostDataType>()
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [submitToggle, setSubmitToggle] = useState<boolean>(false)
@@ -151,6 +157,15 @@ export default function DetailPageAnswerer(props: QuestionDetailProps) {
     // 의존성 배열 eslint 오류 해결 할 것
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const deletePost = async (boardId: string | undefined) => {
+    try {
+      await deleteBoard(boardId as unknown as string)
+      navigate('/questionBoard')
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   return (
     <div>
@@ -399,7 +414,17 @@ export default function DetailPageAnswerer(props: QuestionDetailProps) {
                     <p>게시물 수정하기</p>
                   </div>
                 </Link>
-                <div className="questionDetail_header_sub_modify_delete">
+                <div
+                  className="questionDetail_header_sub_modify_delete"
+                  onClick={() => deletePost(postData?._id)}
+                  onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      deletePost(postData?._id)
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                >
                   <img src="/img/detail_waste_icon.svg" alt="삭제하기" />
                   <p>게시물 삭제하기</p>
                 </div>

--- a/src/styles/questionBoard.scss
+++ b/src/styles/questionBoard.scss
@@ -74,9 +74,12 @@
         }
 
         .question_control {
-          color: $main-color;
           cursor: pointer;
           gap: 16px;
+
+          p {
+            color: $main-color;
+          }
         }
       }
       .question_title {

--- a/src/types/questionBoard.ts
+++ b/src/types/questionBoard.ts
@@ -1,14 +1,17 @@
 export interface IQuestion {
-  id: number
-  point: number
-  type: string
-  date: string
-  title: string
-  photo: string
-  content: string
-  answers: number
+  answers: Array<string>
+  board_access: string
+  board_category: string
+  board_contents: string
+  board_img: Array<string>
+  board_point: number
+  board_title: string
+  create_time: string
+  selected_answer: string
+  status: string
   views: number
-  isAdopted: boolean
+  writer_id: string
+  _id: string
 }
 
 export type TQuestionField = {


### PR DESCRIPTION
## 이야기해 볼 것
### 1.  게시판 글 목록 페이지에서 CRUD 구현했습니다.
실제로 테스트해봐도 정상적으로 작동합니다~
<img width="1552" alt="스크린샷 2023-12-18 오후 4 04 28" src="https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/093fa18f-b54e-4ada-9035-23722eec54a9">

그런데 글 목록을 다 지우고 나면 아래 사진처럼 되더라구요?
<img width="1552" alt="스크린샷 2023-12-18 오후 4 00 15" src="https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/809606ac-c436-4320-8f26-d9ccfbe997b6">

간단하게 퍼블리싱 작업을 해서 
질문 목록이 아예 없을 때는, 질문이 없다고 `질문을 만들어보라~` 라는 문구를 넣어도 좋을 것 같아욤 

### 2. API 주소 변경 시
api 주소가 변경되었더라구요?
이후에는, issue를 생성해서 변경 전 / 변경 후의 api 주소를 작성하면 변경사항을 좀 더 빠르게 반영해 작업할 수 있을 것 같아요!

## 끄적끄적
### 1. 타입스크립트 인터페이스명
저희가 타입으로 명명하거나 인터페이스로 명명할 때 앞에 `T`나 `I`를 붙여왔는데, 요즘 추세는 또 `T`나 `I`를 제거하는 추세로 바뀌었다고 하네요..?
![스크린샷 2023-12-18 오후 4 18 43](https://github.com/Hyodadak-Team/Hyodadak/assets/102431281/9433eb9e-4048-4c7b-8e0e-6a7b69ac278e)
